### PR TITLE
SuggestionList: fix bug with preparation data for resulted list

### DIFF
--- a/leda/src/SuggestionList/SuggestionList.tsx
+++ b/leda/src/SuggestionList/SuggestionList.tsx
@@ -10,6 +10,7 @@ import { getSuggestionItemProps, scrollToSuggestion } from './helpers';
 import { SuggestionItem } from './SuggestionItem';
 import { SuggestionListProps, GroupedSomeObject, Value } from './types';
 import { NoSuggestions } from './NoSuggestions';
+import { SomeObject } from '../../commonTypes';
 
 export const SuggestionList = (props: SuggestionListProps): React.ReactElement | null => {
   const {
@@ -92,21 +93,25 @@ export const SuggestionList = (props: SuggestionListProps): React.ReactElement |
   // group suggestion list items if required
   React.useEffect((): void => {
     // used to keep links
-    const dataItemsMap = new Map<string, Value[]>();
-    const newResultedData = data?.reduce<(Value | GroupedSomeObject)[]>((accumulator, dataValue) => {
-      const key = groupBy?.(dataValue);
+    const indexByKey = new Map<string, number>();
+    let currentResultIndex = 0;
+    const newResultedData = data?.reduce<(Value | GroupedSomeObject)[]>((accumulator, dataItem) => {
+      const key = groupBy ? groupBy(dataItem) : undefined;
       if (key) {
-        const dataItems = dataItemsMap.get(key) || [];
-        if (dataItems.length) {
-          dataItems.push(dataValue);
-        } else {
-          dataItemsMap.set(key, dataItems);
+        if (indexByKey.get(key) === undefined) {
+          indexByKey.set(key, currentResultIndex);
           accumulator.push({
-            key, dataItems,
+            key,
+            dataItems: [],
           });
+          currentResultIndex += 1;
+        }
+        const item = (accumulator as GroupedSomeObject[]).findIndex((elem) => elem.key === key);
+        if (item !== -1) {
+          (accumulator[item] as GroupedSomeObject).dataItems.push(dataItem as SomeObject);
         }
       } else {
-        accumulator.push(dataValue);
+        (accumulator as Value[]).push(dataItem);
       }
       return accumulator;
     }, []) ?? [];

--- a/leda/src/SuggestionList/SuggestionList.tsx
+++ b/leda/src/SuggestionList/SuggestionList.tsx
@@ -93,26 +93,29 @@ export const SuggestionList = (props: SuggestionListProps): React.ReactElement |
   // group suggestion list items if required
   React.useEffect((): void => {
     // used to keep links
-    const indexByKey = new Map<string, number>();
-    let currentResultIndex = 0;
+    const findIndexOfItem = (groupedList: GroupedSomeObject[], dataItem: Value, key?: string): GroupedSomeObject[] => {
+      const itemIndex = groupedList.findIndex((elem) => elem.key === key);
+      if (itemIndex !== -1) {
+        (groupedList[itemIndex] as GroupedSomeObject).dataItems.push(dataItem as SomeObject);
+      }
+      return groupedList;
+    };
+
     const newResultedData = data?.reduce<(Value | GroupedSomeObject)[]>((accumulator, dataItem) => {
       const key = groupBy ? groupBy(dataItem) : undefined;
       if (key) {
-        if (indexByKey.get(key) === undefined) {
-          indexByKey.set(key, currentResultIndex);
+        const isGroupExists = (accumulator as GroupedSomeObject[]).find((item) => item.key === key);
+        if (!isGroupExists) {
           accumulator.push({
             key,
             dataItems: [],
           });
-          currentResultIndex += 1;
         }
-        const item = (accumulator as GroupedSomeObject[]).findIndex((elem) => elem.key === key);
-        if (item !== -1) {
-          (accumulator[item] as GroupedSomeObject).dataItems.push(dataItem as SomeObject);
-        }
-      } else {
-        (accumulator as Value[]).push(dataItem);
+
+        return findIndexOfItem(accumulator as GroupedSomeObject[], dataItem, key);
       }
+
+      (accumulator as Value[]).push(dataItem);
       return accumulator;
     }, []) ?? [];
 


### PR DESCRIPTION
**Describe the bug**
MultiSelect has groups labels only.

**To Reproduce**
Steps to reproduce the behavior:
1. Create groups with items for MultiSelect.
2. Mount it.
3. Open suggestion list for MS.
4. Double groups labels instead of groups and items.

**Expected behavior**
Group items inside groups.

**Screenshots**
![photo_2020-03-02_14-17-10](https://user-images.githubusercontent.com/24355322/75671884-a0244900-5c90-11ea-8c07-56d89964aa80.jpg)

**Environment:**
 - OS: [e.g. Windows 10]
 - Browser [e.g. chrome, firefox]
 - Browser Version [e.g. 22]
 - Leda Version [e.g. 2.0.2]