### PR TITLE
CheckBox: pass classes from the className prop to the wrapper FEND-973

### DIFF
--- a/demo/components/CheckBox.tsx
+++ b/demo/components/CheckBox.tsx
@@ -10,7 +10,7 @@ export const CheckBox = () => {
       <L.Div style={{ display: 'flex' }}>
         <L.Div>
           <L.CheckBox
-            _semi
+            isSemi
             name="CheBoxAry"
             value={value}
             onChange={ev => {
@@ -41,7 +41,7 @@ export const CheckBox = () => {
         </L.Div>
         <L.Div style={{ marginLeft: '20px' }}>
           <L.CheckBox
-            _semi
+            isSemi
             isDisabled
             defaultValue
             onChange={ev => {

--- a/leda/components/CheckBox/CheckBox.test.tsx
+++ b/leda/components/CheckBox/CheckBox.test.tsx
@@ -118,33 +118,55 @@ describe('CheckBox HANDLERS', () => {
 });
 
 describe('CheckBox ATTRIBUTES', () => {
-  describe(', should add classname "semi" to wrapper', () => {
-    it('should have className', () => {
-      const { container } = render(<CheckBox _semi />);
 
+  describe('the basic behavior', () => {
+    it('should contains an input element with checkbox-input class', () => {
+      const { container } = render(<CheckBox />);
       expect(container.querySelector('input')).toHaveClass('checkbox-input');
+    });
+
+    it('should contains a label elemtn with checkbox-label class', () => {
+      const { container } = render(<CheckBox />);
 
       expect(container.querySelector('label')).toHaveClass('checkbox-label');
-
-      expect(container.querySelector('label.checkbox-label')).toHaveClass('semi');
-    });
-
-    it(', should convert props to classes', () => {
-      const { container } = render(<CheckBox _active />);
-
-      expect(container.querySelector('.checkbox-label.box')).toBeNull();
-
-      expect(container.querySelector('.checkbox-label.active')).toBeInTheDocument();
-    });
-
-    it('classes passed through className should not override prop-classes', () => {
-      const { container } = render(<CheckBox className="test" _active />);
-
-      expect(container.querySelector('.checkbox-label.test')).toBeInTheDocument();
-
-      expect(container.querySelector('.checkbox-label.active')).toBeInTheDocument();
     });
   });
+
+
+  describe('converete _props to classes', () => {
+    it('should converte a _semi prop to the semi class name and add it to the wrapper', () => {
+      const { container } = render(<CheckBox _semi />);
+
+      expect(container.querySelector('span')).toHaveClass('semi');
+    });
+
+    it('should combine _prop and className value in valid style classes', () => {
+      const { container } = render(<CheckBox _active className="test" />);
+
+      expect(container.querySelector('span')).toHaveClass('active');
+      expect(container.querySelector('span')).toHaveClass('test');
+    });
+  });
+
+  describe('visual states', () => {
+    it('should not add the semi class to the label by default', () => {
+      const { container } = render(<CheckBox />);
+
+      expect(container.querySelector('label')!.classList.contains('semi')).toBe(false);
+    });
+
+    it('should not add the semi class to the label if an isSemi prop defined as false', () => {
+      const { container } = render(<CheckBox isSemi={false} />);
+
+      expect(container.querySelector('label')!.classList.contains('semi')).toBe(false);
+    });
+
+    it('should add the semi class to the label if an isSemi prop is defined', () => {
+      const {container} = render(<CheckBox isSemi />);
+
+      expect(container.querySelector('label')!.classList.contains('semi')).toBe(true);
+    });
+  })
 
   describe('children prop', () => {
     it('children should have correct className', () => {

--- a/leda/components/CheckBox/index.tsx
+++ b/leda/components/CheckBox/index.tsx
@@ -17,6 +17,7 @@ export const CheckBox = React.forwardRef((props: CheckBoxProps, ref?: React.Ref<
     id,
     inputRender,
     isDisabled,
+    isSemi,
     labelRender,
     name,
     onChange,
@@ -53,7 +54,9 @@ export const CheckBox = React.forwardRef((props: CheckBoxProps, ref?: React.Ref<
     props,
   );
 
-  const labelClassNames = getClassNames(theme.label, className);
+  const wrapperClassName = getClassNames(className)
+
+  const labelClassNames = getClassNames(theme.label, isSemi ? 'semi' : null);
 
   const checkBoxId = id || `checkbox-${generateId()}`;
 
@@ -61,6 +64,7 @@ export const CheckBox = React.forwardRef((props: CheckBoxProps, ref?: React.Ref<
 
   return (
     <Wrapper
+      className={wrapperClassName}
       ref={ref && ((component) => {
         const wrapper = component ? (component.wrapper || component as unknown as HTMLElement) : null;
 

--- a/leda/components/CheckBox/types.ts
+++ b/leda/components/CheckBox/types.ts
@@ -21,6 +21,10 @@ export interface CheckBoxProps {
   inputRender?: CustomRender<CheckBoxProps, {}, React.InputHTMLAttributes<HTMLInputElement>>,
   /** Отключение чекбокса */
   isDisabled?: boolean,
+  
+  /** Флаг частичного выбора */
+  isSemi?: boolean,
+
   /** Кастомизация элемента label */
   labelRender?: CustomRender<CheckBoxProps, {}, React.LabelHTMLAttributes<any>>,
   /** Имя компонента */

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "npm run clean && npm run tsc && npm run sass",
     "lint": "eslint --color --ext .ts,.tsx leda",
     "test": "jest --color --silent",
+    "test:watch": "jest --color --silent --watch",
     "tsc": "tsc",
     "jest": "jest",
     "cypress": "start-test wds 9000 cypress:open",


### PR DESCRIPTION
- instead of defined semi state as a style class, use isSemi prop
- pass both _props and className to the wrapper instead of label element
- update test cases because of a changed syntax
- update the CheckBox demo because of a changed syntax 