### PR TITLE
DatePicker: change color for the prev/next moth days

### DIFF
--- a/styles/themes/light/components/Calendar/_calendar.scss
+++ b/styles/themes/light/components/Calendar/_calendar.scss
@@ -163,14 +163,12 @@
         border-radius: 50%;
 
         &.different-month-date {
+          color: $black-04;
+          
           &:hover {
             background-color: $primary-05;
             color: $black-01;
           }
-        }
-
-        &.day-off {
-
         }
 
         &.today {


### PR DESCRIPTION
Now it is gray.

<img width="275" alt="DatePicker-FEND-945" src="https://user-images.githubusercontent.com/9029842/82302569-71ca2600-99c2-11ea-9e81-e889ae510b2e.png">
