### PR TITLE
DatePicker: change a date by pressing the enter key if the DatePicker is in the isOpen mode.

### DIFF
--- a/leda/components/DatePicker/DatePicker.test.tsx
+++ b/leda/components/DatePicker/DatePicker.test.tsx
@@ -85,6 +85,18 @@ describe.skip('DatePicker HANDLERS', () => {
     expect(event.target.name).toEqual(wrapper.props().name);
   });
 
+  it('should call onChange if the DatePicker is showen and an enter event was called on the callendar', () => {
+    const onChangeHandler = jest.fn();
+    const wrapper = mount(<DatePicker show />);
+
+    wrapper.setProps({ value: new Date('1985-10-31') });
+    wrapper.update();
+    wrapper.find('Icon').simulate('onclick');
+    wrapper.find({title: '30'}).first().simulate('onkeydown', {key: 'Enter', code: 'Enter'});
+
+    expect(onChangeHandler).toHaveBeenCalled();
+  });
+
   it('should call onFocus from inside', () => {
     const onFocusHandler = jest.fn();
     const wrapper = mount(<DatePicker name="pipicker" onFocus={onFocusHandler} />);

--- a/leda/src/DateTimeInput/handlers/handleKeyDown.ts
+++ b/leda/src/DateTimeInput/handlers/handleKeyDown.ts
@@ -227,30 +227,33 @@ const handleDownKeyPress = (payload: UpDownKeyPressPayload): void => {
   }
 };
 
+/**
+ * Обработчик нажатия клавиш
+ * @param payload {EnterKyePressPayload}
+ */
 const handleEnterKeyPress = (payload: EnterKeyPressPayload): void => {
   const {
-    isOpen, onEnterPress, ev, name, date, value, viewType,
-    viewDate, type, dateShorthand, min, max, format = 'dd.MM.yyyy', dispatch, onChange, maskedInputRef,
+    isOpen, 
+    onEnterPress, 
+    ev, 
+    name, 
+    date, 
+    value, 
+    viewType,
+    viewDate, 
+    type, 
+    dateShorthand, 
+    min, 
+    max, 
+    format = 'dd.MM.yyyy', 
+    dispatch, 
+    onChange, 
+    maskedInputRef,
   } = payload;
 
   const {
     year, month,
   } = dateShorthand;
-  // если календарь закрыт - вызывать onEnterPress
-  if (!isOpen) {
-    if (isFunction(onEnterPress)) {
-      onEnterPress({
-        ...ev,
-        component: {
-          date,
-          name,
-          value,
-        },
-      });
-    }
-
-    return;
-  }
 
   const updateDate = (newDate: Date): void => {
     // неконтролируемый режим
@@ -430,8 +433,22 @@ export const createKeyDownHandler = ({
     }
     case KEYS.ENTER: {
       handleEnterKeyPress({
-        dateShorthand, ev, isOpen, max, min, viewType, onEnterPress, name, date, type, value, viewDate,
-        dispatch, format, onChange, maskedInputRef,
+        dateShorthand, 
+        ev, 
+        isOpen, 
+        max, 
+        min, 
+        viewType, 
+        onEnterPress, 
+        name, 
+        date, 
+        type, 
+        value, 
+        viewDate,
+        dispatch, 
+        format, 
+        onChange, 
+        maskedInputRef,
       });
       break;
     }


### PR DESCRIPTION
- Remove unnecessary part of code which occurs the unexpected behavior.
- Add new test case for this action.